### PR TITLE
(fix): Puppet 7.14.0 System Auth DB read.

### DIFF
--- a/lib/puppet/provider/authpluginmech/ruby.rb
+++ b/lib/puppet/provider/authpluginmech/ruby.rb
@@ -7,7 +7,7 @@ Puppet::Type.type(:authpluginmech).provide(:ruby) do
 
     def get_auth_plist
         begin
-            output = security(['authorizationdb', 'read', 'system.login.console'])
+            output = security(['-q', 'authorizationdb', 'read', 'system.login.console'])
         rescue Puppet::ExecutionFailure => e
             Puppet.debug "#get_auth_plist had an error -> #{e.inspect}"
             return {}


### PR DESCRIPTION
The following adds the `-q` flag to the Authorisation DB command to suppress the trailing `YES (0)` from the output as it seems to break parsing the of the plist on puppet 7.14.0.


 

