### PR TITLE
Add macOS 26 compatibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,7 @@ authpluginmech { 'My Awesome mech:
     insert_after => 'MCXMechanism:login'
 }
 ```
+
+## macOS Version Compatibility
+
+Tested and compatible with macOS 26 (Tahoe).


### PR DESCRIPTION
Adds a macOS Version Compatibility section noting this module is tested and compatible with macOS 26 (Tahoe).